### PR TITLE
Added a few demo-ready configurations

### DIFF
--- a/gitpod-backstage/examples/components/petstore-component.yaml
+++ b/gitpod-backstage/examples/components/petstore-component.yaml
@@ -11,6 +11,8 @@ metadata:
     - url: https://github.com/swagger-api/swagger-petstore
       title: GitHub Repo
       icon: github
+  annotations:
+    github.com/project-slug: swagger-api/swagger-petstore
 spec:
   type: service
   lifecycle: experimental

--- a/gitpod-backstage/packages/app/src/App.tsx
+++ b/gitpod-backstage/packages/app/src/App.tsx
@@ -75,7 +75,7 @@ const app = createApp({
 const routes = (
   <FlatRoutes>
     <Route path="/" element={<Navigate to="catalog" />} />
-    <Route path="/catalog" element={<CatalogIndexPage />} />
+    <Route path="/catalog" element={<CatalogIndexPage initiallySelectedFilter="all"/>} />
     <Route
       path="/catalog/:namespace/:kind/:name"
       element={<CatalogEntityPage />}


### PR DESCRIPTION
Updated the petstore component to contain the github project-slug (so the Gitpod button is active)
Updated the "CatalogIndexPage" component, so the default view is "all components" instead of owned by the user